### PR TITLE
Fixed get storageclass command

### DIFF
--- a/preparing-kubernetes-cluster.html.md.erb
+++ b/preparing-kubernetes-cluster.html.md.erb
@@ -81,7 +81,7 @@ Most of the Kubernetes distributed by the public clouds come with a default stor
 To verify that your Kubernetes cluster already has a default storage class installed, retrieve the list of StorageClass resources in the cluster:
 
 ```bash
-kubectl get storage class
+kubectl get storageclass
 ```
 
 Review the returned list of StorageClass resources:


### PR DESCRIPTION
Command in the preparing your kubernetes doc, the command to get storageclass in the kubernetes cluster is incorrect.